### PR TITLE
feat: Implement README generation for subcomponents

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -33,7 +33,7 @@ The same goes for each component.`,
 	}
 
 	cmd.Flags().StringP("project", "p", ".", "The path to the gitlab CI component project")
-	cmd.Flags().StringP("output", "o", "README.md", "The path to the output file. Relative to the projet directory")
+	cmd.Flags().StringP("output", "o", "README.md", "The path to the output file. Relative to the project directory")
 
 	cmd.Flags().String("header", "HEADER.md", "File to prepended to the list of components")
 	cmd.Flags().String("footer", "FOOTER.md", "File to appended to the list of components")
@@ -42,6 +42,7 @@ The same goes for each component.`,
 	cmd.Flags().String("component-footer", "FOOTER.md", "File to appended on component. The file must exist in the component directory")
 
 	cmd.Flags().Int("component-header-level", 2, "The level of the header for each component")
+	cmd.Flags().Bool("generate-subcomponent-readmes", false, "Enable write a README.md to each component")
 
 	// bind flags to viper
 	viper.BindPFlag("project", cmd.Flags().Lookup("project"))
@@ -54,6 +55,7 @@ The same goes for each component.`,
 	viper.BindPFlag("component-footer", cmd.Flags().Lookup("component-footer"))
 
 	viper.BindPFlag("component-header-level", cmd.Flags().Lookup("component-header-level"))
+	viper.BindPFlag("generate-subcomponent-readmes", cmd.Flags().Lookup("generate-subcomponent-readmes"))
 
 	return cmd
 }
@@ -95,7 +97,27 @@ func generateReadme() error {
 			return err
 		}
 		// render markdown
-		sb.WriteString(c.Markdown())
+
+		if viper.GetBool("generate-subcomponent-readmes") {
+			var csb strings.Builder
+
+			// render markdown for component
+			csb.WriteString(c.Markdown(false))
+
+			// write generated markdown to component folder
+			err := os.WriteFile(filepath.Join(viper.GetString("project"), "templates", c.Name, viper.GetString("output")), []byte(strings.TrimSpace(csb.String())+"\n"), 0644)
+			if err != nil {
+				return err
+			}
+
+			// generate markdown for root README with hyperlinks to each component readme
+			sb.WriteString(c.Markdown(true))
+			continue
+		}
+
+		// generate markdown for root README without hyperlinks
+		sb.WriteString(c.Markdown(false))
+
 	}
 
 	if _, err := os.Stat(filepath.Join(viper.GetString("project"), viper.GetString("footer"))); err == nil {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -102,7 +102,7 @@ func generateReadme() error {
 			var csb strings.Builder
 
 			// render markdown for component
-			csb.WriteString(c.Markdown(false))
+			csb.WriteString(c.Markdown(false, viper.GetString("output")))
 
 			// write generated markdown to component folder
 			err := os.WriteFile(filepath.Join(viper.GetString("project"), "templates", c.Name, viper.GetString("output")), []byte(strings.TrimSpace(csb.String())+"\n"), 0644)
@@ -111,12 +111,12 @@ func generateReadme() error {
 			}
 
 			// generate markdown for root README with hyperlinks to each component readme
-			sb.WriteString(c.Markdown(true))
+			sb.WriteString(c.Markdown(true, viper.GetString("output")))
 			continue
 		}
 
 		// generate markdown for root README without hyperlinks
-		sb.WriteString(c.Markdown(false))
+		sb.WriteString(c.Markdown(false, viper.GetString("output")))
 
 	}
 

--- a/pkg/gitlab/components.go
+++ b/pkg/gitlab/components.go
@@ -142,7 +142,7 @@ type Component struct {
 	Spec   *ComponentSpec `yaml:"spec"`
 }
 
-func (c *Component) Markdown() string {
+func (c *Component) Markdown(isRoot bool) string {
 
 	if c.Header == "" && c.Footer == "" && c.Spec == nil {
 		return ""
@@ -151,7 +151,11 @@ func (c *Component) Markdown() string {
 	var md strings.Builder
 
 	// render component header
-	md.WriteString(fmt.Sprintf("%s %s\n\n", headerLevel(), c.Name))
+	if isRoot {
+		md.WriteString(fmt.Sprintf("%s %s\n\n", headerLevel(), fmt.Sprintf("[%s](templates/%s/README.md)", c.Name, c.Name)))
+	} else {
+		md.WriteString(fmt.Sprintf("%s %s\n\n", headerLevel(), c.Name))
+	}
 
 	if c.Header != "" {
 		md.WriteString(strings.TrimSpace(c.Header) + "\n\n")

--- a/pkg/gitlab/components.go
+++ b/pkg/gitlab/components.go
@@ -142,7 +142,7 @@ type Component struct {
 	Spec   *ComponentSpec `yaml:"spec"`
 }
 
-func (c *Component) Markdown(isRoot bool) string {
+func (c *Component) Markdown(isRoot bool, outputFilename string) string {
 
 	if c.Header == "" && c.Footer == "" && c.Spec == nil {
 		return ""
@@ -151,10 +151,14 @@ func (c *Component) Markdown(isRoot bool) string {
 	var md strings.Builder
 
 	// render component header
+	header := fmt.Sprintf("%s %s\n\n", headerLevel(), "%s")
 	if isRoot {
-		md.WriteString(fmt.Sprintf("%s %s\n\n", headerLevel(), fmt.Sprintf("[%s](templates/%s/README.md)", c.Name, c.Name)))
+		if outputFilename == "" {
+			outputFilename = "README.md"
+		}
+		md.WriteString(fmt.Sprintf(header, fmt.Sprintf("[%s](templates/%s/%s)", c.Name, c.Name, outputFilename)))
 	} else {
-		md.WriteString(fmt.Sprintf("%s %s\n\n", headerLevel(), c.Name))
+		md.WriteString(fmt.Sprintf(header, c.Name))
 	}
 
 	if c.Header != "" {

--- a/pkg/gitlab/components_test.go
+++ b/pkg/gitlab/components_test.go
@@ -213,7 +213,7 @@ spec:
 		component := &Component{Name: "Component test"}
 		yaml.Unmarshal([]byte(input), component)
 
-		assert.Equal(t, expected.String(), component.Markdown())
+		assert.Equal(t, expected.String(), component.Markdown(false, ""))
 
 	})
 
@@ -234,7 +234,7 @@ Some Header
 		component := &Component{Name: "Header test", Header: "Some Header"}
 		yaml.Unmarshal([]byte(input), component)
 
-		assert.Equal(t, expected.String(), component.Markdown())
+		assert.Equal(t, expected.String(), component.Markdown(false, ""))
 
 	})
 
@@ -256,7 +256,7 @@ Header
 		component := &Component{Name: "Header test", Header: "Some\nHeader\n"}
 		yaml.Unmarshal([]byte(input), component)
 
-		assert.Equal(t, expected.String(), component.Markdown())
+		assert.Equal(t, expected.String(), component.Markdown(false, ""))
 
 	})
 
@@ -275,7 +275,7 @@ Header
 		component := &Component{Name: "Footer test", Footer: "Some Footer"}
 		yaml.Unmarshal([]byte(input), component)
 
-		assert.Equal(t, expected.String(), component.Markdown())
+		assert.Equal(t, expected.String(), component.Markdown(false, ""))
 
 	})
 
@@ -296,7 +296,28 @@ Header
 		component := &Component{Name: "Header level test"}
 		yaml.Unmarshal([]byte(input), component)
 
-		assert.Equal(t, expected.String(), component.Markdown())
+		assert.Equal(t, expected.String(), component.Markdown(false, ""))
+
+	})
+
+	t.Run("test hyperlinks in root of document and write to output", func(t *testing.T) {
+
+		viper.Set("output", "test.md")
+
+		var expected strings.Builder
+		expected.WriteString(`### [hyperlink-test](templates/hyperlink-test/test.md)
+
+| Input / Variable | Description | Default value |
+| ---------------- | ----------- | ------------- |
+`)
+		expected.WriteString(fmt.Sprintf("| `job-prefix`     | Define a prefix for the job name | %c             |\n", '\U000026D4'))
+
+		expected.WriteString("\n")
+
+		component := &Component{Name: "hyperlink-test"}
+		yaml.Unmarshal([]byte(input), component)
+
+		assert.Equal(t, expected.String(), component.Markdown(true, viper.GetString("output")))
 
 	})
 


### PR DESCRIPTION
- Add new command-line flag `--generate-subcomponent-readmes`
- Generate separate README files for each subcomponent